### PR TITLE
Fix installing single certificates

### DIFF
--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -29,11 +29,8 @@ foreach($cert in $pfx) {
   if($cert.Thumbprint -ne "<%= @thumbprint %>") {
       $intermediatestore.Add($cert)
   }
-  elseif($cert.Thumbprint -eq "<%= @thumbprint %>") {
-      $store.Add($cert)
-  }
   else {
-    exit 0
+      $store.Add($cert)
   }
 }
 

--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -45,7 +45,12 @@ if (($pfx -ne $null) -and ($installedCerts -ne $null) -and ($intermediateCerts -
         }
     }
 
-    if (($installedCertCount + $installedIntermediateCount) -eq $pfx.Count) {
+    # When $pfx.Count is $null, $pfx is an instance of X509Certificate2, not X509Certificate2Collection, so
+    # ensure that only a single certificate has been installed.
+    if (($pfx.Count -eq $null) -and ($installedCertCount -eq 1) -and ($installedIntermediateCount -eq 0)) {
+        exit 1
+    }
+    elseif (($installedCertCount + $installedIntermediateCount) -eq $pfx.Count) {
         exit 1
     }
 }

--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -36,26 +36,18 @@ if (($pfx -ne $null) -and ($installedCerts -ne $null) -and ($intermediateCerts -
                 }
             }
         }
-        elseif ($cert.Thumbprint -eq "<%= @thumbprint %>") {
+        else {
             foreach ($installedCert in $installedCerts) {
                 if($installedCert.Thumbprint -eq $cert.Thumbprint) {
                     $installedCertCount ++
                 }
             }
         }
-        else {
-            exit 0
-        }
     }
 
     if (($installedCertCount + $installedIntermediateCount) -eq $pfx.Count) {
         exit 1
     }
-    else {
-        exit 0
-    }
-}
-else {
-    exit 0
 }
 
+exit 0


### PR DESCRIPTION
When installing a certificate from a single certificate file format which uses `X509Certificate2` the existing if condition will always be false since `$pfx.Count` is `$null`. Add an additional check to prevent this from being applied on every single run.